### PR TITLE
Add culture override to USILOperand.ToString() to fix decimal formatting issues during export

### DIFF
--- a/ShaderTextRestorer/UltraShaderConverter/USIL/USILOperand.cs
+++ b/ShaderTextRestorer/UltraShaderConverter/USIL/USILOperand.cs
@@ -2,6 +2,7 @@
 using DirectXDisassembler.Blocks;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -211,9 +212,9 @@ namespace ShaderLabConvert
                             for (int i = 0; i < immValueFloat.Length; i++)
                             {
                                 if (i != immValueFloat.Length - 1)
-                                    body += $"{immValueFloat[i]}, ";
+                                    body += $"{immValueFloat[i].ToString(CultureInfo.InvariantCulture)}, ";
                                 else
-                                    body += $"{immValueFloat[i]}";
+                                    body += $"{immValueFloat[i].ToString(CultureInfo.InvariantCulture)}";
                             }
                             body += ")";
                         }

--- a/ShaderTextRestorer/UltraShaderConverter/USIL/USILOperand.cs
+++ b/ShaderTextRestorer/UltraShaderConverter/USIL/USILOperand.cs
@@ -203,7 +203,7 @@ namespace ShaderLabConvert
                     {
                         if (immValueFloat.Length == 1)
                         {
-                            body = $"{immValueFloat[0]}";
+                            body = $"{immValueFloat[0].ToString(CultureInfo.InvariantCulture)}";
                         }
                         else //if (immValueFloat.Length > 1)
                         {


### PR DESCRIPTION
This only modifies in one place currently, but can be extended as needed